### PR TITLE
Make trie.Database.Commit() write out preimages in deterministic order 

### DIFF
--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -20,12 +20,15 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // StateDB is an EVM database for full state querying.
 type StateDB interface {
 	CreateAccount(common.Address)
+
+	RawDump() state.Dump
 
 	SubBalance(common.Address, *big.Int)
 	AddBalance(common.Address, *big.Int)

--- a/trie/database.go
+++ b/trie/database.go
@@ -17,8 +17,10 @@
 package trie
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"sort"
 	"sync"
 	"time"
 
@@ -615,9 +617,26 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 	start := time.Now()
 	batch := db.diskdb.NewBatch()
 
+	type kvPair struct {
+		key   []byte
+		value []byte
+	}
+
+	// Sort preimages to ensure they are written out in deterministic order
+	orderedPreimages := make([]kvPair, 0, len(db.preimages))
+	for hash := range db.preimages {
+		orderedPreimages = append(orderedPreimages, kvPair{
+			key:   common.CopyBytes(hash[:]),
+			value: db.preimages[hash],
+		})
+	}
+	sort.Slice(orderedPreimages, func(j, k int) bool {
+		return bytes.Compare(orderedPreimages[j].key, orderedPreimages[k].key) < 0
+	})
+
 	// Move all of the accumulated preimages into a write batch
-	for hash, preimage := range db.preimages {
-		if err := batch.Put(db.secureKey(hash[:]), preimage); err != nil {
+	for _, preimage := range orderedPreimages {
+		if err := batch.Put(db.secureKey(preimage.key), preimage.value); err != nil {
 			log.Error("Failed to commit preimage from trie database", "err", err)
 			db.lock.RUnlock()
 			return err


### PR DESCRIPTION
Iteration order over `db.preimages` was not deterministic, sorting the
batch contents when the batch is written wasn't enough to work around
this if `preimages` didn't fit into a single batch. So now `Commit()` will
pre-sort `preimages` to ensure their order is always deterministic, even
when split across multiple batches.