### PR TITLE
Revert unnecessary commits

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -77,9 +77,8 @@ type stateObject struct {
 	trie Trie // storage trie, which becomes non-nil on first access
 	code Code // contract bytecode, which gets set when code is loaded
 
-	originStorage    Storage       // Storage cache of original entries to dedup rewrites
-	dirtyStorage     Storage       // Storage entries that need to be flushed to disk
-	dirtyStorageKeys []common.Hash // Dirty storage keys in order of insertion into dirtyStorage
+	originStorage Storage // Storage cache of original entries to dedup rewrites
+	dirtyStorage  Storage // Storage entries that need to be flushed to disk
 
 	// Cache flags.
 	// When an object is marked suicided it will be delete from the trie
@@ -112,13 +111,12 @@ func newObject(db *StateDB, address common.Address, data Account) *stateObject {
 		data.CodeHash = emptyCodeHash
 	}
 	return &stateObject{
-		db:               db,
-		address:          address,
-		addrHash:         crypto.Keccak256Hash(address[:]),
-		data:             data,
-		originStorage:    make(Storage),
-		dirtyStorage:     make(Storage),
-		dirtyStorageKeys: nil,
+		db:            db,
+		address:       address,
+		addrHash:      crypto.Keccak256Hash(address[:]),
+		data:          data,
+		originStorage: make(Storage),
+		dirtyStorage:  make(Storage),
 	}
 }
 
@@ -214,21 +212,12 @@ func (self *stateObject) SetState(db Database, key, value common.Hash) {
 
 func (self *stateObject) setState(key, value common.Hash) {
 	self.dirtyStorage[key] = value
-	for _, k := range self.dirtyStorageKeys {
-		if k == key {
-			return
-		}
-	}
-	self.dirtyStorageKeys = append(self.dirtyStorageKeys, key)
 }
 
 // updateTrie writes cached storage modifications into the object's storage trie.
 func (self *stateObject) updateTrie(db Database) Trie {
 	tr := self.getTrie(db)
-	// Iterate through the storage keys in deterministic order to ensure the storage trie is
-	// identical across machines
-	for _, key := range self.dirtyStorageKeys {
-		value := self.dirtyStorage[key]
+	for key, value := range self.dirtyStorage {
 		delete(self.dirtyStorage, key)
 
 		// Skip noop changes, persist actual changes
@@ -314,7 +303,6 @@ func (self *stateObject) deepCopy(db *StateDB) *stateObject {
 	}
 	stateObject.code = self.code
 	stateObject.dirtyStorage = self.dirtyStorage.Copy()
-	stateObject.dirtyStorageKeys = append([]common.Hash{}, self.dirtyStorageKeys...)
 	stateObject.originStorage = self.originStorage.Copy()
 	stateObject.suicided = self.suicided
 	stateObject.dirtyCode = self.dirtyCode

--- a/trie/database.go
+++ b/trie/database.go
@@ -17,10 +17,8 @@
 package trie
 
 import (
-	"bytes"
 	"fmt"
 	"io"
-	"sort"
 	"sync"
 	"time"
 
@@ -617,26 +615,9 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 	start := time.Now()
 	batch := db.diskdb.NewBatch()
 
-	type kvPair struct {
-		key   []byte
-		value []byte
-	}
-
-	// Sort preimages to ensure they are written out in deterministic order
-	orderedPreimages := make([]kvPair, 0, len(db.preimages))
-	for hash := range db.preimages {
-		orderedPreimages = append(orderedPreimages, kvPair{
-			key:   common.CopyBytes(hash[:]),
-			value: db.preimages[hash],
-		})
-	}
-	sort.Slice(orderedPreimages, func(j, k int) bool {
-		return bytes.Compare(orderedPreimages[j].key, orderedPreimages[k].key) < 0
-	})
-
 	// Move all of the accumulated preimages into a write batch
-	for _, preimage := range orderedPreimages {
-		if err := batch.Put(db.secureKey(preimage.key), preimage.value); err != nil {
+	for hash, preimage := range db.preimages {
+		if err := batch.Put(db.secureKey(hash[:]), preimage); err != nil {
 			log.Error("Failed to commit preimage from trie database", "err", err)
 			db.lock.RUnlock()
 			return err


### PR DESCRIPTION
We have added code that makes updating and committing state trie deterministically by sorting keys. However, the order of inserted keys is not necessary, since the root hash of trie is calculated by the nodes of tries. As long as the node values and the number of nodes are identical across nodes, root hashes will be deterministic. This PR reverts the unnecessary commits that slow down the nodes. 

Note: this should not require any feature flags since the order does not affect the root hash.