### PR TITLE
Unsorting state update commit

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"os"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -28,7 +29,7 @@ import (
 )
 
 var emptyCodeHash = crypto.Keccak256(nil)
-var sorting = false
+var unsorting = (os.Getenv("GOETH_UNSORTING") == "true")
 
 type Code []byte
 
@@ -215,7 +216,7 @@ func (self *stateObject) SetState(db Database, key, value common.Hash) {
 
 func (self *stateObject) setState(key, value common.Hash) {
 	self.dirtyStorage[key] = value
-	if sorting {
+	if !unsorting {
 		for _, k := range self.dirtyStorageKeys {
 			if k == key {
 				return
@@ -228,7 +229,7 @@ func (self *stateObject) setState(key, value common.Hash) {
 // updateTrie writes cached storage modifications into the object's storage trie.
 func (self *stateObject) updateTrie(db Database) Trie {
 	tr := self.getTrie(db)
-	if sorting {
+	if !unsorting {
 		// Iterate through the storage keys in deterministic order to ensure the storage trie is
 		// identical across machines
 		for _, key := range self.dirtyStorageKeys {
@@ -337,7 +338,7 @@ func (self *stateObject) deepCopy(db *StateDB) *stateObject {
 	}
 	stateObject.code = self.code
 	stateObject.dirtyStorage = self.dirtyStorage.Copy()
-	if sorting {
+	if !unsorting {
 		stateObject.dirtyStorageKeys = append([]common.Hash{}, self.dirtyStorageKeys...)
 	}
 	stateObject.originStorage = self.originStorage.Copy()

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"os"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -29,7 +28,7 @@ import (
 )
 
 var emptyCodeHash = crypto.Keccak256(nil)
-var unsorting = (os.Getenv("GOETH_UNSORTING") == "true")
+var EnableStateObjectDirtyStorageKeysSorting = true
 
 type Code []byte
 
@@ -216,7 +215,7 @@ func (self *stateObject) SetState(db Database, key, value common.Hash) {
 
 func (self *stateObject) setState(key, value common.Hash) {
 	self.dirtyStorage[key] = value
-	if !unsorting {
+	if EnableStateObjectDirtyStorageKeysSorting {
 		for _, k := range self.dirtyStorageKeys {
 			if k == key {
 				return
@@ -229,7 +228,7 @@ func (self *stateObject) setState(key, value common.Hash) {
 // updateTrie writes cached storage modifications into the object's storage trie.
 func (self *stateObject) updateTrie(db Database) Trie {
 	tr := self.getTrie(db)
-	if !unsorting {
+	if EnableStateObjectDirtyStorageKeysSorting {
 		// Iterate through the storage keys in deterministic order to ensure the storage trie is
 		// identical across machines
 		for _, key := range self.dirtyStorageKeys {
@@ -338,7 +337,7 @@ func (self *stateObject) deepCopy(db *StateDB) *stateObject {
 	}
 	stateObject.code = self.code
 	stateObject.dirtyStorage = self.dirtyStorage.Copy()
-	if !unsorting {
+	if EnableStateObjectDirtyStorageKeysSorting {
 		stateObject.dirtyStorageKeys = append([]common.Hash{}, self.dirtyStorageKeys...)
 	}
 	stateObject.originStorage = self.originStorage.Copy()

--- a/trie/database.go
+++ b/trie/database.go
@@ -617,6 +617,76 @@ func (db *Database) Commit(node common.Hash, report bool) error {
 	start := time.Now()
 	batch := db.diskdb.NewBatch()
 
+	// Move all of the accumulated preimages into a write batch
+	for hash, preimage := range db.preimages {
+		if err := batch.Put(db.secureKey(hash[:]), preimage); err != nil {
+			log.Error("Failed to commit preimage from trie database", "err", err)
+			db.lock.RUnlock()
+			return err
+		}
+		if batch.ValueSize() > ethdb.IdealBatchSize {
+			if err := batch.Write(); err != nil {
+				return err
+			}
+			batch.Reset()
+		}
+	}
+	// Move the trie itself into the batch, flushing if enough data is accumulated
+	nodes, storage := len(db.nodes), db.nodesSize
+	if err := db.commit(node, batch); err != nil {
+		log.Error("Failed to commit trie from trie database", "err", err)
+		db.lock.RUnlock()
+		return err
+	}
+	// Write batch ready, unlock for readers during persistence
+	if err := batch.Write(); err != nil {
+		log.Error("Failed to write trie to disk", "err", err)
+		db.lock.RUnlock()
+		return err
+	}
+	db.lock.RUnlock()
+
+	// Write successful, clear out the flushed data
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	db.preimages = make(map[common.Hash][]byte)
+	db.preimagesSize = 0
+
+	db.uncache(node)
+
+	memcacheCommitTimeTimer.Update(time.Since(start))
+	memcacheCommitSizeMeter.Mark(int64(storage - db.nodesSize))
+	memcacheCommitNodesMeter.Mark(int64(nodes - len(db.nodes)))
+
+	logger := log.Info
+	if !report {
+		logger = log.Debug
+	}
+	logger("Persisted trie from memory database", "nodes", nodes-len(db.nodes)+int(db.flushnodes), "size", storage-db.nodesSize+db.flushsize, "time", time.Since(start)+db.flushtime,
+		"gcnodes", db.gcnodes, "gcsize", db.gcsize, "gctime", db.gctime, "livenodes", len(db.nodes), "livesize", db.nodesSize)
+
+	// Reset the garbage collection statistics
+	db.gcnodes, db.gcsize, db.gctime = 0, 0, 0
+	db.flushnodes, db.flushsize, db.flushtime = 0, 0, 0
+
+	return nil
+}
+
+// Commit iterates over all the children of a particular node, writes them out
+// to disk, forcefully tearing down all references in both directions.
+//
+// As a side effect, all pre-images accumulated up to this point are also written.
+func (db *Database) Commit2(node common.Hash, report bool) error {
+	// Create a database batch to flush persistent data out. It is important that
+	// outside code doesn't see an inconsistent state (referenced data removed from
+	// memory cache during commit but not yet in persistent storage). This is ensured
+	// by only uncaching existing data when the database write finalizes.
+	db.lock.RLock()
+
+	start := time.Now()
+	batch := db.diskdb.NewBatch()
+
 	type kvPair struct {
 		key   []byte
 		value []byte

--- a/trie/database.go
+++ b/trie/database.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"sync"
 	"time"
@@ -45,7 +44,7 @@ var (
 	memcacheCommitNodesMeter = metrics.NewRegisteredMeter("trie/memcache/commit/nodes", nil)
 	memcacheCommitSizeMeter  = metrics.NewRegisteredMeter("trie/memcache/commit/size", nil)
 
-	unsorting = (os.Getenv("GOETH_UNSORTING") == "true")
+	EnableTrieDatabasePreimageKeysSorting = true
 )
 
 // secureKeyPrefix is the database key prefix used to store trie node preimages.
@@ -607,10 +606,10 @@ func (db *Database) Cap(limit common.StorageSize) error {
 }
 
 func (db *Database) Commit(node common.Hash, report bool) error {
-	if unsorting {
-		return db.unsortCommit(node, report)
+	if EnableTrieDatabasePreimageKeysSorting {
+		return db.sortCommit(node, report)
 	}
-	return db.sortCommit(node, report)
+	return db.unsortCommit(node, report)
 }
 
 // Commit iterates over all the children of a particular node, writes them out


### PR DESCRIPTION
This PR adds `GOETH_UNSORTING` environment variable to switch on/off sorting keys before updating and committing state. 